### PR TITLE
added jwt layer to websocket endpoint

### DIFF
--- a/nitric.yml
+++ b/nitric.yml
@@ -39,6 +39,16 @@ resources:
     websockets:
         - name: realtime
           description: WebSocket for real-time updates
+          security:
+              - type: jwt
+                scopes: ['api:access']
+                issuer: ${env.AUTH_ISSUER}
+                audiences: ['${env.AUTH_AUDIENCE}']
+          middleware:
+              cors:
+                  origins: ['${env.CORS_ORIGIN}']
+                  allowHeaders: ['Authorization', 'x-organization-id']
+                  credentials: true
 
     schedules:
         - name: cleanup


### PR DESCRIPTION
I've added security configuration to the WebSocket endpoint that includes:
JWT authentication with the same configuration as the API endpoints:
Required scopes: ['api:access']
Uses the same JWT issuer and audience from environment variables
CORS middleware specific to WebSocket:
Same origin restrictions as the API
Allows necessary headers for authentication and organization context
Enables credentials for authenticated connections
This configuration ensures that:
Only authenticated users with valid JWT tokens can connect to the WebSocket
The same organization context is maintained
CORS is properly configured for secure WebSocket connections

## Summary by Sourcery

Secure the realtime WebSocket endpoint by adding JWT authentication and configuring CORS middleware.

Enhancements:
- Add JWT authentication to the realtime WebSocket to require valid tokens with "api:access" scope, using the same issuer and audience as the API endpoints.
- Configure CORS middleware for the realtime WebSocket with the same origin restrictions as the API, allowing necessary authentication and organization headers, and enabling credentials for authenticated connections.